### PR TITLE
fix mode set to int octal instead of octal notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project uses [Semantic Versioning](https://semver.org/) - MAJOR.MINOR.PATCH
 
 # Changelog
 
+Saltext.Prometheus 2.0.2 (2023-03-13)
+=====================================
+
+Fixed
+-----
+
+- Fix mode set to int octal instead of octal notation (#21)
+
+
 Saltext.Prometheus 2.0.1 (2023-03-12)
 =====================================
 

--- a/src/saltext/prometheus/returners/prometheus_textfile.py
+++ b/src/saltext/prometheus/returners/prometheus_textfile.py
@@ -426,7 +426,6 @@ def returner(ret):
         salt.modules.file.chown(opts["filename"], opts["uid"], opts["gid"])
         if opts["mode"]:
             try:
-                opts["mode"] = int(opts["mode"], base=8)
                 salt.modules.file.set_mode(opts["filename"], opts["mode"])
             except ValueError:
                 opts["mode"] = None

--- a/src/saltext/prometheus/version.py
+++ b/src/saltext/prometheus/version.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/tests/unit/returners/test_prometheus_textfile_return.py
+++ b/tests/unit/returners/test_prometheus_textfile_return.py
@@ -8,6 +8,7 @@ import salt.utils.files
 import salt.version
 import saltext.prometheus.returners.prometheus_textfile as prometheus_textfile
 
+from tests.support.mock import MagicMock
 from tests.support.mock import patch
 
 
@@ -571,3 +572,13 @@ def test_requisite_handling(patch_dunders, cache_dir, minion):
     prometheus_textfile.returner(job_ret)
 
     assert Path(os.path.join(cache_dir, "prometheus_textfile", "salt.prom")).exists()
+
+
+def test_mode_passed_to_set_mode(patch_dunders, cache_dir, job_ret, minion):
+    mock_set_mode = MagicMock(return_value=True)
+    prometheus_textfile.__opts__.update({"mode": "0644"})
+    with patch("salt.modules.file.set_mode", mock_set_mode):
+        prometheus_textfile.returner(job_ret)
+    mock_set_mode.assert_called_with(
+        os.path.join(cache_dir, "prometheus_textfile", "salt.prom"), "0644"
+    )


### PR DESCRIPTION
### What does this PR do?
Fixes permissions set incorrectly in transition from full text file management (int octal) to `salt.modules.file.set_mode` management (octal notation).

### Previous Behavior
`0644` passed as mode would be converted to `420`

### New Behavior
`0644` is retained through passing to `salt.modules.file.set_mode` 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
