### PR TITLE
Correct docs URL

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -6,8 +6,8 @@ author: EITR Technologies, LLC
 author_email: devops@eitr.tech
 coc_contact: devops@eitr.tech
 copyright_begin: 2022
-deploy_docs: rolling
-docs_url: https://salt-extensions.github.io/saltext-prometheus/
+deploy_docs: never
+docs_url: https://saltext-prometheus.readthedocs.io/en/latest/
 integration_name: Prometheus
 license: apache
 loaders:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     name: CI
     uses: salt-extensions/central-artifacts/.github/workflows/ci.yml@main
     with:
-      deploy-docs: true
+      deploy-docs: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,7 +23,7 @@ jobs:
     needs: get_tag_version
     uses: salt-extensions/central-artifacts/.github/workflows/ci.yml@main
     with:
-      deploy-docs: true
+      deploy-docs: false
       release: true
       version: ${{ needs.get_tag_version.outputs.version }}
     permissions:

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ appreciate every contribution!
 [PRs]: https://github.com/salt-extensions/saltext-prometheus/pulls
 [discussions]: https://github.com/salt-extensions/saltext-prometheus/discussions
 [comments]: https://conventionalcomments.org/
-[docs]: https://salt-extensions.github.io/saltext-prometheus/
+[docs]: https://saltext-prometheus.readthedocs.io/en/latest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ content-type = "text/markdown"
 
 [project.urls]
 Homepage = "https://github.com/salt-extensions/saltext-prometheus"
-Documentation = "https://salt-extensions.github.io/saltext-prometheus/"
+Documentation = "https://saltext-prometheus.readthedocs.io/en/latest/"
 Source = "https://github.com/salt-extensions/saltext-prometheus"
 Tracker = "https://github.com/salt-extensions/saltext-prometheus/issues"
 


### PR DESCRIPTION
### What does this PR do?
Corrects docs URL from GitHub Pages to RTD.

Earlier, the docs URL was set to Salt core documentation, which is why I assumed there were no built docs. Later, I found https://saltext-prometheus.readthedocs.io/en/latest/.

### What issues does this PR fix or reference?
Fixes:

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes